### PR TITLE
fix: stackvector expand

### DIFF
--- a/public/blah/containers/stackvector.h
+++ b/public/blah/containers/stackvector.h
@@ -129,7 +129,7 @@ namespace Blah
 			int count = m_count;
 
 			for (int i = 0; i < amount; i++)
-				new (data() + count + i) T(item);
+				new (data() + count + i) T();
 
 			m_count += amount;
 			return &data()[count];


### PR DESCRIPTION
I found your game framework/engine/thing and checked out a couple of your archived streams. I am using it as a learning resource for my own game project. I tried to build the library and hit the following error:

stackvector.h:132:32: error: use of undeclared identifier 'item'
                                new (data() + count + i) T(item);

It appears that the StackVector::expand function has a little copy paste error on line 132. When expanding a vector, empty type T's should be added to the vector instead of trying to copy the non-existent T, 'item'.

Thanks for making this available for all of us out here.

