### PR TITLE
Add required headers to compile on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ endif()
 
 # Link and create SDL2 Definition if we're using SDL2
 if (SDL2_ENABLED)
+	find_package(SDL2 REQUIRED)
 	add_compile_definitions(BLAH_USE_SDL2)
 	target_include_directories(blah PUBLIC "$<BUILD_INTERFACE:${SDL2_INCLUDE_DIRS}>")
 	set(LIBS ${LIBS} ${SDL2_LIBRARIES})

--- a/include/blah/containers/stackvector.h
+++ b/include/blah/containers/stackvector.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <blah/core/log.h>
 #include <new>
+#include <initializer_list>
 
 namespace Blah
 {

--- a/include/blah/containers/str.h
+++ b/include/blah/containers/str.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <inttypes.h>
 #include <stdarg.h>
+#include <cstdio>
 #include <blah/containers/vector.h>
 
 namespace Blah

--- a/include/blah/core/log.h
+++ b/include/blah/core/log.h
@@ -5,18 +5,18 @@
 
 	#include <stdlib.h>
 	#define BLAH_ERROR(message) \
-		do { Log::error(message "\n\tin file: %s:%d", __FILE__, __LINE__); abort(); } while(0)
+		do { Blah::Log::error(message "\n\tin file: %s:%d", __FILE__, __LINE__); abort(); } while(0)
 
 	#define BLAH_ERROR_FMT(message, ...) \
-		do { Log::error(message "\n\tin file: %s:%d", __VA_ARGS__, __FILE__, __LINE__); abort(); } while(0)
+		do { Blah::Log::error(message "\n\tin file: %s:%d", __VA_ARGS__, __FILE__, __LINE__); abort(); } while(0)
 
 #else
 
 	#define BLAH_ERROR(message) \
-		Log::error(message "\n\tin file: %s:%d", __FILE__, __LINE__)
+		Blah::Log::error(message "\n\tin file: %s:%d", __FILE__, __LINE__)
 
 	#define BLAH_ERROR_FMT(message, ...) \
-		Log::error(message "\n\tin file: %s:%d", __VA_ARGS__, __FILE__, __LINE__)
+		Blah::Log::error(message "\n\tin file: %s:%d", __VA_ARGS__, __FILE__, __LINE__)
 
 #endif
 

--- a/src/drawing/batch.cpp
+++ b/src/drawing/batch.cpp
@@ -6,6 +6,7 @@
 #include <blah/graphics/material.h>
 #include <blah/math/calc.h>
 #include <blah/core/app.h>
+#include <cmath>
 
 using namespace Blah;
 namespace

--- a/src/graphics/material.cpp
+++ b/src/graphics/material.cpp
@@ -1,5 +1,6 @@
 #include <blah/graphics/material.h>
 #include <blah/core/log.h>
+#include <cstring>
 
 using namespace Blah;
 

--- a/src/internal/platform_backend.h
+++ b/src/internal/platform_backend.h
@@ -114,7 +114,9 @@ namespace Blah
 		void gl_context_make_current(void* context);
 		void gl_context_destroy(void* context);
 
+#if _WIN32
 		// D3D11 Methods
 		void* d3d11_get_hwnd();
+#endif
 	}
 }

--- a/src/internal/platform_backend_sdl2.cpp
+++ b/src/internal/platform_backend_sdl2.cpp
@@ -649,6 +649,7 @@ void PlatformBackend::gl_context_destroy(void* context)
 	SDL_GL_DeleteContext(context);
 }
 
+#if _WIN32
 void* PlatformBackend::d3d11_get_hwnd()
 {
 	SDL_SysWMinfo info;
@@ -656,5 +657,5 @@ void* PlatformBackend::d3d11_get_hwnd()
 	SDL_GetWindowWMInfo(window, &info);
 	return info.info.win.window;
 }
-
+#endif
 #endif // BLAH_USE_SDL2


### PR DESCRIPTION
Fixes to make blah work on macos. Mainly needed to import headers, add a `Blah::` qualifier somewhere, and enclose a function in `#if _WIN32` because it cannot compile in macos. The first two are probably non-macos issues, but your visual studio toolchain just doesn't throw an error on those.