### PR TITLE
Emscripten build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,13 +89,16 @@ endif()
 # Link and create SDL2 Definition if we're using it
 if (SDL2_ENABLED)
 	add_compile_definitions(BLAH_USE_SDL2)
-
-	if (NOT DEFINED SDL2_INCLUDE_DIRS OR NOT DEFINED SDL2_LIBRARIES)
-		find_package(SDL2 REQUIRED)
+	if (${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
+  		set_target_properties(blah PROPERTIES COMPILE_FLAGS "-s USE_SDL=2")
+	else()
+		if (NOT DEFINED SDL2_INCLUDE_DIRS OR NOT DEFINED SDL2_LIBRARIES)
+			find_package(SDL2 REQUIRED)
+		endif()
+		
+		target_include_directories(blah PUBLIC "$<BUILD_INTERFACE:${SDL2_INCLUDE_DIRS}>")
+		set(LIBS ${LIBS} ${SDL2_LIBRARIES})
 	endif()
-	
-	target_include_directories(blah PUBLIC "$<BUILD_INTERFACE:${SDL2_INCLUDE_DIRS}>")
-	set(LIBS ${LIBS} ${SDL2_LIBRARIES})
 endif()
 
 target_link_libraries(blah PUBLIC ${LIBS})

--- a/src/drawing/batch.cpp
+++ b/src/drawing/batch.cpp
@@ -19,7 +19,11 @@ namespace
 
 	const ShaderData shader_data = {
 		// vertex shader
+#ifdef __EMSCRIPTEN__
+		"#version 300 es\n"
+#else
 		"#version 330\n"
+#endif
 		"uniform mat4 u_matrix;\n"
 		"layout(location=0) in vec2 a_position;\n"
 		"layout(location=1) in vec2 a_tex;\n"
@@ -37,7 +41,12 @@ namespace
 		"}",
 
 		// fragment shader
+#ifdef __EMSCRIPTEN__
+		"#version 300 es\n"
+		"precision mediump float;\n"
+#else
 		"#version 330\n"
+#endif
 		"uniform sampler2D u_texture;\n"
 		"in vec2 v_tex;\n"
 		"in vec4 v_col;\n"

--- a/src/internal/platform_backend_sdl2.cpp
+++ b/src/internal/platform_backend_sdl2.cpp
@@ -81,6 +81,10 @@ bool PlatformBackend::init(const Config* config)
 	{
 		flags |= SDL_WINDOW_OPENGL;
 
+#ifdef __EMSCRIPTEN__
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+#else
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
@@ -93,6 +97,7 @@ bool PlatformBackend::init(const Config* config)
 		SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4);
+#endif
 	}
 	// enable DirectX
 	else if (App::renderer() == Renderer::D3D11)
@@ -140,9 +145,11 @@ bool PlatformBackend::init(const Config* config)
 
 void PlatformBackend::ready()
 {
+#ifndef __EMSCRIPTEN__
 	// enable V-Sync
 	if (App::renderer() == Renderer::OpenGL)
 		SDL_GL_SetSwapInterval(1);
+#endif
 }
 
 void PlatformBackend::shutdown()


### PR DESCRIPTION
Enabling building for web using emscripten. Changes required:

- An SDL2 port is included with emscripten, just set `-s USE_SDL=2` linker flag
- Move main loop iteration into function to use as a callback for emscripten_set_main_loop()
- Use opengl es

After installing emscripten, the build process is pretty straightforward (just need to wrap cmake configure). For example:
```
cd build/web
emcmake cmake -G "Unix Makefiles"  ../../
make
```