### PR TITLE
Update blend factors for BlendMode::normal 

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -5,10 +5,10 @@ using namespace Blah;
 
 const BlendMode BlendMode::Normal = BlendMode(
 	BlendOp::Add,
-	BlendFactor::One,
+	BlendFactor::SrcAlpha,
 	BlendFactor::OneMinusSrcAlpha,
 	BlendOp::Add,
-	BlendFactor::One,
+	BlendFactor::SrcAlpha,
 	BlendFactor::OneMinusSrcAlpha,
 	BlendMask::RGBA,
 	0xffffffff


### PR DESCRIPTION
I might be getting this backwards but it looks like the blend factors of `ONE` and `SRC_ALPHA_MINUS_ONE` are not right for a `normal` blend mode.  Although the results are fairly similar most of the time, playground: https://www.andersriggelsen.dk/glblendfunc.php

<img width="837" alt="Screen Shot 2022-05-23 at 12 32 34" src="https://user-images.githubusercontent.com/4985932/169855256-8edea221-88d1-444e-ba5b-182a47a9d5f2.png">

<img width="875" alt="Screen Shot 2022-05-23 at 12 32 29" src="https://user-images.githubusercontent.com/4985932/169855221-6e76d302-b090-4647-b12d-f03decb2beb1.png">


