### PR TITLE
Use correct rect overlap check

### DIFF
--- a/include/blah_spatial.h
+++ b/include/blah_spatial.h
@@ -727,7 +727,7 @@ namespace Blah
 
 	template<class T>
 	constexpr bool Rect<T>::overlaps(const Rect& rect) const {
-		return x + w >= rect.x && y + h >= rect.y && x < rect.x + rect.w && y < rect.y + rect.h;
+		return x + w > rect.x && y + h > rect.y && x < rect.x + rect.w && y < rect.y + rect.h;
 	}
 
 	template<class T>


### PR DESCRIPTION
I'm sure this rect overlap check is incorrect. A rect at 0,0 with width 50 wouldn't overlap a rect at 50,0 would it?

This change fixes an issue in `tiny_link` where the player falls through `jumpthru` masks. https://github.com/NoelFB/tiny_link/blob/main/src/components/mover.cpp#L48

[video of issue in tiny_link](https://user-images.githubusercontent.com/42767280/219964091-f04eeb12-6b7f-4a12-844b-1028ea46eba0.webm)

When jumping on a fall thru platform there's a 1 pixel gap as it thinks there's a collision there.
![image of gap in collision](https://user-images.githubusercontent.com/42767280/219964206-cd15ee9b-477f-4644-8c12-5f005898f904.png)

I'm not sure how this was working before.